### PR TITLE
Restore Fax Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.4] - 2023-08-30
+
+### Fixed
+
+- Restore `create()` and `update()` methods on FaxInstance and FaxListInstance namespaces.
+
 ## [3.1.3] - 2023-08-04
 
 ### Changed

--- a/lib/rest/fax/v1/fax.d.ts
+++ b/lib/rest/fax/v1/fax.d.ts
@@ -30,11 +30,27 @@ type FaxUpdateStatus = 'canceled';
  */
 declare function FaxList(version: V1): FaxListInstance;
 
+/**
+ * Options to pass to update
+ *
+ * @property status - The new status of the resource
+ */
+interface FaxInstanceUpdateOptions {
+  status?: FaxUpdateStatus;
+}
+
 interface FaxListInstance {
   /**
    * @param sid - sid of instance
    */
   (sid: string): FaxContext;
+  /**
+   * create a FaxInstance
+   *
+   * @param opts - Options for request
+   * @param callback - Callback to handle processed record
+   */
+  create(opts: FaxListInstanceCreateOptions, callback?: (error: Error | null, item: FaxInstance) => any): Promise<FaxInstance>;
   /**
    * Streams FaxInstance records from the API.
    *
@@ -141,6 +157,31 @@ interface FaxListInstance {
    * Provide a user-friendly representation
    */
   toJSON(): any;
+}
+
+/**
+ * Options to pass to create
+ *
+ * @property from - The number the fax was sent from
+ * @property mediaUrl - The URL of the PDF that contains the fax
+ * @property quality - The quality of this fax
+ * @property sipAuthPassword - The password for SIP authentication
+ * @property sipAuthUsername - The username for SIP authentication
+ * @property statusCallback - The URL we should call to send status information to your application
+ * @property storeMedia - Whether to store a copy of the sent media
+ * @property to - The phone number to receive the fax
+ * @property ttl - How long in minutes to try to send the fax
+ */
+interface FaxListInstanceCreateOptions {
+  from?: string;
+  mediaUrl: string;
+  quality?: FaxQuality;
+  sipAuthPassword?: string;
+  sipAuthUsername?: string;
+  statusCallback?: string;
+  storeMedia?: boolean;
+  to: string;
+  ttl?: number;
 }
 
 /**
@@ -281,6 +322,19 @@ declare class FaxContext {
    * Provide a user-friendly representation
    */
   toJSON(): any;
+    /**
+   * update a FaxInstance
+   *
+   * @param callback - Callback to handle processed record
+   */
+  update(callback?: (error: Error | null, items: FaxInstance) => any): Promise<FaxInstance>;
+  /**
+   * update a FaxInstance
+   *
+   * @param opts - Options for request
+   * @param callback - Callback to handle processed record
+   */
+  update(opts?: FaxInstanceUpdateOptions, callback?: (error: Error | null, items: FaxInstance) => any): Promise<FaxInstance>;
 }
 
 
@@ -335,6 +389,19 @@ declare class FaxInstance extends SerializableClass {
    * Provide a user-friendly representation
    */
   toJSON(): any;
+    /**
+   * update a FaxInstance
+   *
+   * @param callback - Callback to handle processed record
+   */
+  update(callback?: (error: Error | null, items: FaxInstance) => any): Promise<FaxInstance>;
+  /**
+   * update a FaxInstance
+   *
+   * @param opts - Options for request
+   * @param callback - Callback to handle processed record
+   */
+  update(opts?: FaxInstanceUpdateOptions, callback?: (error: Error | null, items: FaxInstance) => any): Promise<FaxInstance>;
   url: string;
 }
 
@@ -364,4 +431,4 @@ declare class FaxPage extends Page<V1, FaxPayload, FaxResource, FaxInstance> {
   toJSON(): any;
 }
 
-export { FaxContext, FaxDirection, FaxInstance, FaxList, FaxListInstance, FaxListInstanceEachOptions, FaxListInstanceOptions, FaxListInstancePageOptions, FaxPage, FaxPayload, FaxQuality, FaxResource, FaxSolution, FaxStatus, FaxUpdateStatus }
+export { FaxContext, FaxDirection, FaxInstance, FaxInstanceUpdateOptions, FaxList, FaxListInstance, FaxListInstanceCreateOptions, FaxListInstanceEachOptions, FaxListInstanceOptions, FaxListInstancePageOptions, FaxPage, FaxPayload, FaxQuality, FaxResource, FaxSolution, FaxStatus, FaxUpdateStatus }

--- a/lib/rest/fax/v1/fax.js
+++ b/lib/rest/fax/v1/fax.js
@@ -326,6 +326,70 @@ FaxList = function FaxList(version) {
 
   /* jshint ignore:start */
   /**
+   * create a FaxInstance
+   *
+   * @function create
+   * @memberof Twilio.Fax.V1.FaxList#
+   *
+   * @param {object} opts - Options for request
+   * @param {string} opts.to - The phone number to receive the fax
+   * @param {string} opts.mediaUrl - The URL of the PDF that contains the fax
+   * @param {fax.quality} [opts.quality] - The quality of this fax
+   * @param {string} [opts.statusCallback] -
+   *          The URL we should call to send status information to your application
+   * @param {string} [opts.from] - The number the fax was sent from
+   * @param {string} [opts.sipAuthUsername] - The username for SIP authentication
+   * @param {string} [opts.sipAuthPassword] - The password for SIP authentication
+   * @param {boolean} [opts.storeMedia] - Whether to store a copy of the sent media
+   * @param {number} [opts.ttl] - How long in minutes to try to send the fax
+   * @param {function} [callback] - Callback to handle processed record
+   *
+   * @returns {Promise} Resolves to processed FaxInstance
+   */
+  /* jshint ignore:end */
+  FaxListInstance.create = function create(opts, callback) {
+    if (_.isUndefined(opts)) {
+      throw new Error('Required parameter "opts" missing.');
+    }
+    if (_.isUndefined(opts['to'])) {
+      throw new Error('Required parameter "opts[\'to\']" missing.');
+    }
+    if (_.isUndefined(opts['mediaUrl'])) {
+      throw new Error('Required parameter "opts[\'mediaUrl\']" missing.');
+    }
+
+    var deferred = Q.defer();
+    var data = values.of({
+      'To': _.get(opts, 'to'),
+      'MediaUrl': _.get(opts, 'mediaUrl'),
+      'Quality': _.get(opts, 'quality'),
+      'StatusCallback': _.get(opts, 'statusCallback'),
+      'From': _.get(opts, 'from'),
+      'SipAuthUsername': _.get(opts, 'sipAuthUsername'),
+      'SipAuthPassword': _.get(opts, 'sipAuthPassword'),
+      'StoreMedia': serialize.bool(_.get(opts, 'storeMedia')),
+      'Ttl': _.get(opts, 'ttl')
+    });
+
+    var promise = this._version.create({uri: this._uri, method: 'POST', data: data});
+
+    promise = promise.then(function(payload) {
+      deferred.resolve(new FaxInstance(this._version, payload, this._solution.sid));
+    }.bind(this));
+
+    promise.catch(function(error) {
+      deferred.reject(error);
+    });
+
+    if (_.isFunction(callback)) {
+      deferred.promise.nodeify(callback);
+    }
+
+    return deferred.promise;
+  };
+
+  /* jshint ignore:start */
+  /**
    * Constructs a fax
    *
    * @function get
@@ -523,6 +587,24 @@ FaxInstance.prototype.fetch = function fetch(callback) {
 
 /* jshint ignore:start */
 /**
+ * update a FaxInstance
+ *
+ * @function update
+ * @memberof Twilio.Fax.V1.FaxInstance#
+ *
+ * @param {object} [opts] - Options for request
+ * @param {fax.update_status} [opts.status] - The new status of the resource
+ * @param {function} [callback] - Callback to handle processed record
+ *
+ * @returns {Promise} Resolves to processed FaxInstance
+ */
+/* jshint ignore:end */
+FaxInstance.prototype.update = function update(opts, callback) {
+  return this._proxy.update(opts, callback);
+};
+
+/* jshint ignore:start */
+/**
  * remove a FaxInstance
  *
  * @function remove
@@ -617,6 +699,47 @@ FaxContext = function FaxContext(version, sid) {
 FaxContext.prototype.fetch = function fetch(callback) {
   var deferred = Q.defer();
   var promise = this._version.fetch({uri: this._uri, method: 'GET'});
+
+  promise = promise.then(function(payload) {
+    deferred.resolve(new FaxInstance(this._version, payload, this._solution.sid));
+  }.bind(this));
+
+  promise.catch(function(error) {
+    deferred.reject(error);
+  });
+
+  if (_.isFunction(callback)) {
+    deferred.promise.nodeify(callback);
+  }
+
+  return deferred.promise;
+};
+
+/* jshint ignore:start */
+/**
+ * update a FaxInstance
+ *
+ * @function update
+ * @memberof Twilio.Fax.V1.FaxContext#
+ *
+ * @param {object} [opts] - Options for request
+ * @param {fax.update_status} [opts.status] - The new status of the resource
+ * @param {function} [callback] - Callback to handle processed record
+ *
+ * @returns {Promise} Resolves to processed FaxInstance
+ */
+/* jshint ignore:end */
+FaxContext.prototype.update = function update(opts, callback) {
+  if (_.isFunction(opts)) {
+    callback = opts;
+    opts = {};
+  }
+  opts = opts || {};
+
+  var deferred = Q.defer();
+  var data = values.of({'Status': _.get(opts, 'status')});
+
+  var promise = this._version.update({uri: this._uri, method: 'POST', data: data});
 
   promise = promise.then(function(payload) {
     deferred.resolve(new FaxInstance(this._version, payload, this._solution.sid));

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire Compatibility API",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "keywords": [
     "signalwire",
     "voice",

--- a/spec/integration/rest/fax/v1/fax.spec.js
+++ b/spec/integration/rest/fax/v1/fax.spec.js
@@ -309,6 +309,123 @@ describe('Fax', function() {
       }).done();
     }
   );
+  it('should generate valid create request',
+    function(done) {
+      holodeck.mock(new Response(500, {}));
+
+      var opts = {'to': 'to', 'mediaUrl': 'https://example.com'};
+      var promise = client.fax.v1.faxes.create(opts);
+      promise.then(function() {
+        throw new Error('failed');
+      }, function(error) {
+        expect(error.constructor).toBe(RestException.prototype.constructor);
+        done();
+      }).done();
+
+      var url = 'https://fax.twilio.com/v1/Faxes';
+
+      var values = {'To': 'to', 'MediaUrl': 'https://example.com', };
+      holodeck.assertHasRequest(new Request({
+          method: 'POST',
+          url: url,
+          data: values
+      }));
+    }
+  );
+  it('should generate valid create response',
+    function(done) {
+      var body = {
+          'account_sid': 'ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          'api_version': 'v1',
+          'date_created': '2015-07-30T20:00:00Z',
+          'date_updated': '2015-07-30T20:00:00Z',
+          'direction': 'outbound',
+          'from': '+14155551234',
+          'media_url': null,
+          'media_sid': null,
+          'num_pages': null,
+          'price': null,
+          'price_unit': null,
+          'quality': 'superfine',
+          'sid': 'FXaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          'status': 'queued',
+          'to': '+14155554321',
+          'duration': null,
+          'links': {
+              'media': 'https://fax.twilio.com/v1/Faxes/FXaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Media'
+          },
+          'url': 'https://fax.twilio.com/v1/Faxes/FXaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      };
+
+      holodeck.mock(new Response(201, body));
+
+      var opts = {'to': 'to', 'mediaUrl': 'https://example.com'};
+      var promise = client.fax.v1.faxes.create(opts);
+      promise.then(function(response) {
+        expect(response).toBeDefined();
+        done();
+      }, function() {
+        throw new Error('failed');
+      }).done();
+    }
+  );
+  it('should generate valid update request',
+    function(done) {
+      holodeck.mock(new Response(500, {}));
+
+      var promise = client.fax.v1.faxes('FXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update();
+      promise.then(function() {
+        throw new Error('failed');
+      }, function(error) {
+        expect(error.constructor).toBe(RestException.prototype.constructor);
+        done();
+      }).done();
+
+      var sid = 'FXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+      var url = `https://fax.twilio.com/v1/Faxes/${sid}`;
+
+      holodeck.assertHasRequest(new Request({
+        method: 'POST',
+        url: url
+      }));
+    }
+  );
+  it('should generate valid update response',
+    function(done) {
+      var body = {
+          'account_sid': 'ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          'api_version': 'v1',
+          'date_created': '2015-07-30T20:00:00Z',
+          'date_updated': '2015-07-30T20:00:00Z',
+          'direction': 'outbound',
+          'from': '+14155551234',
+          'media_url': null,
+          'media_sid': null,
+          'num_pages': null,
+          'price': null,
+          'price_unit': null,
+          'quality': 'fine',
+          'sid': 'FXaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          'status': 'canceled',
+          'to': '+14155554321',
+          'duration': null,
+          'links': {
+              'media': 'https://fax.twilio.com/v1/Faxes/FXaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Media'
+          },
+          'url': 'https://fax.twilio.com/v1/Faxes/FXaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      };
+
+      holodeck.mock(new Response(200, body));
+
+      var promise = client.fax.v1.faxes('FXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update();
+      promise.then(function(response) {
+        expect(response).toBeDefined();
+        done();
+      }, function() {
+        throw new Error('failed');
+      }).done();
+    }
+  );
   it('should generate valid remove request',
     function(done) {
       holodeck.mock(new Response(500, {}));


### PR DESCRIPTION
Just restore `.create()` and `.update()` methods on the FaxListInstance and FaxInstance.