### PR TITLE
Update axios package to latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node: [ 14, 16, 18]
+        node: [ 16, 18, 20]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2025-09-30
+
+### Changed
+
+- Update axios dependency to 1.12.2 to address security vulnerability (CVE-2024-39338).
+- Drop support for Node.js 14 (EOL) - minimum supported version is now Node.js 16.
+- Update CI testing to Node.js 16, 18, and 20.
+
+### Fixed
+
+- Add mdurl type override to resolve dependency conflicts.
+
 ## [3.1.4] - 2023-08-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,44 @@ Read the implementation documentation, guides and API Reference at the official 
 
 ---
 
+## Node.js Version Support
+
+As of version 3.2.0, this library requires Node.js 16 or higher. Support for Node.js 14 (which reached end-of-life in April 2023) has been dropped.
+
+### Using with Node.js 14
+
+If you need to use this library with Node.js 14, you have two options:
+
+**Option 1: Install the last compatible version (recommended)**
+
+```bash
+npm install @signalwire/compatibility-api@3.1.4
+```
+
+**Option 2: Override dependencies (advanced, not recommended)**
+
+If you absolutely must use the latest version with Node.js 14, you can attempt to override the engine check and axios version, though this is not tested or supported:
+
+```json
+{
+  "dependencies": {
+    "@signalwire/compatibility-api": "^3.2.0"
+  },
+  "overrides": {
+    "@signalwire/compatibility-api": {
+      "axios": "^1.6.2"
+    }
+  },
+  "engines": {
+    "node": ">=14"
+  }
+}
+```
+
+**Note:** This override approach may result in security vulnerabilities or unexpected behavior. We strongly recommend upgrading to Node.js 16 or higher.
+
+---
+
 ## Contributing
 
 SignalWire Compatibility SDK is open source and maintained by the SignalWire team, but we are very grateful for [everyone](https://github.com/signalwire/compatibility-api-js/contributors) who has contributed and assisted so far.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://developer.signalwire.com/compatibility-api",
   "dependencies": {
-    "axios": "^1.6.2",
+    "axios": "^1.12.2",
     "dayjs": "^1.8.29",
     "https-proxy-agent": "^5.0.0",
     "jsonwebtoken": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "test": "npm run test:javascript && npm run test:typescript",
     "test:javascript": "jasmine spec/**/**.spec.js",
-    "test:typescript": "tsc examples/typescript/example.ts --noEmit --strict --skipLibCheck",
+    "test:typescript": "tsc examples/typescript/example.ts --noEmit --strict",
     "jshint": "jshint lib/rest/** lib/base/** lib/http/**",
     "jscs": "eslint lib/base/**/**.js lib/http/**/**.js --fix",
     "check": "npm run jshint && npm run jscs",
@@ -81,5 +81,8 @@
   "types": "./compatibility-api.d.ts",
   "engines": {
     "node": ">=12"
+  },
+  "overrides": {
+    "@types/mdurl": "1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire Compatibility API",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "keywords": [
     "signalwire",
     "voice",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "test": "npm run test:javascript && npm run test:typescript",
     "test:javascript": "jasmine spec/**/**.spec.js",
-    "test:typescript": "tsc examples/typescript/example.ts --noEmit --strict",
+    "test:typescript": "tsc examples/typescript/example.ts --noEmit --strict --skipLibCheck",
     "jshint": "jshint lib/rest/** lib/base/** lib/http/**",
     "jscs": "eslint lib/base/**/**.js lib/http/**/**.js --fix",
     "check": "npm run jshint && npm run jscs",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "types": "./compatibility-api.d.ts",
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "overrides": {
     "@types/mdurl": "1.0.5"


### PR DESCRIPTION
```
# npm audit report

  axios  <1.12.0
  Severity: high
  Axios is vulnerable to DoS attack through lack of data size check - https://github.com/advisories/GHSA-4hjh-wcwx-xvwj
  fix available via `npm audit fix --force`
  Will install @signalwire/compatibility-api@3.0.5, which is a breaking change
  node_modules/axios
    @signalwire/compatibility-api  >=3.1.0-alpha.202305151818.680ae15bc.0
    Depends on vulnerable versions of axios
    node_modules/@signalwire/compatibility-api
```

https://www.npmjs.com/package/axios

Several potentially breaking changes between 1.6.2 and 1.12.2:

  TypeScript-Related Changes
  - Type discrepancies between ESM and CJS were resolved in 1.9.0
  - AxiosResponse interface extensions in 1.8.0
  - Type guard changes for the isCancel method
  - Constructor changes - config argument became optional

  Behavioral Changes
  - Headers handling modifications - support for multiple header values
  - URL building changes - absolute URL handling updates
  - Fetch adapter introduction in 1.7.0 (though it falls back gracefully)